### PR TITLE
fix(dependencies): Use safer version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   ],
   "repository": "e0ipso/ajv-inspector",
   "dependencies": {
-    "ajv": ">=3.8.0",
-    "lodash": ">=3.10.1",
-    "request": ">=2.69.0"
+    "ajv": "~4.11.7",
+    "lodash": "~4.17.4",
+    "request": "~2.81.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",


### PR DESCRIPTION
It appears that changes in ajv at 5.0.0 have broken modules that depend on ajv-inspector. The specifics have not been tracked down yet but this will prevent breakage among other dependents.