### PR TITLE
feat: bump ajv to ^5.0.0

### DIFF
--- a/lib/ajv-inspector.js
+++ b/lib/ajv-inspector.js
@@ -41,40 +41,12 @@ class AjvInspector {
    *   It resolves after the schema has been successfully compiled.
    */
   compile() {
-    return new Promise((resolve, reject) => {
-      this.ajv.compileAsync(this.schema, (err, validate) => {
-        if (err) {
-          return reject(err);
-        }
-        this.compiled = validate;
+    return this.ajv.compileAsync(this.schema)
+      .then(compiled => {
+        this.compiled = compiled;
         // Return the compiled schema.
-        resolve(validate);
+        return compiled;
       });
-    });
-  }
-
-  /**
-   * Compile the schema and store it in memory.
-   *
-   * @throws {Error}
-   *   If schema cannot be compiled.
-   *
-   * @return {void}
-   */
-  compileSync() {
-    const _compileSchema = object => {
-      try {
-        return this.ajv.compile(object);
-      }
-      catch (e) {
-        const uri = e.missingSchema;
-        let subSchema = {};
-        this.ajv._opts.loadSchema(uri, (err, res) => subSchema = res);
-        this.ajv.addSchema(subSchema, uri.replace(/#\/?$/, ''));
-        return _compileSchema(object);
-      }
-    };
-    this.compiled = _compileSchema(this.schema);
   }
 
   /**
@@ -84,27 +56,27 @@ class AjvInspector {
    *
    * @param {string} uri
    *   The URI for the schema to load.
-   * @param {Function} callback
-   *   The assync callback to call.
    *
    * @return {void}
    */
-  static httpSchemaLoader(uri, callback) {
+  static httpSchemaLoader(uri) {
     if (typeof globalSchemas[uri] !== 'undefined') {
-      callback(null, globalSchemas[uri]);
-      return;
+      return Promise.resolve(globalSchemas[uri]);
     }
-    request.get(uri, {}, (err, res, body) => {
-      if (err || res.statusCode >= 400) {
-        return callback(err || new Error('Loading error: ' + res.statusCode));
-      }
-      try {
-        globalSchemas[uri] = JSON.parse(body);
-      }
-      catch (error) {
-        return callback(error);
-      }
-      callback(null, globalSchemas[uri]);
+
+    return new Promise((resolve, reject) => {
+      request.get(uri, {}, (err, res, body) => {
+        if (err || res.statusCode >= 400) {
+          return reject(err || new Error('Loading error: ' + res.statusCode));
+        }
+        try {
+          globalSchemas[uri] = JSON.parse(body);
+        }
+        catch (error) {
+          return reject(error);
+        }
+        return resolve(globalSchemas[uri]);
+      });
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ajv-inspector",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "Uses ajv to compile a JSON Schema and lets you inspect it.",
   "main": "lib/ajv-inspector.js",
   "scripts": {
@@ -18,7 +18,7 @@
   ],
   "repository": "e0ipso/ajv-inspector",
   "dependencies": {
-    "ajv": "~4.11.7",
+    "ajv": "^5.5.2",
     "lodash": "~4.17.4",
     "request": "~2.83.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -48,36 +48,37 @@ module.exports = {
         cb();
       },
       httpSchemaLoader(test) {
-        test.expect(2);
-        SchemaInspector.httpSchemaLoader('fake.json', (err, data) => {
-          test.ok(!err);
-          test.ok(data.success === true);
-          test.done();
-        });
+        test.expect(1);
+        SchemaInspector.httpSchemaLoader('fake.json')
+          .then(data => {
+            test.ok(data.success === true);
+            test.done();
+          });
       },
       httpSchemaLoaderCache(test) {
-        test.expect(2);
+        test.expect(1);
         // Make a second call to load from cache.
-        SchemaInspector.httpSchemaLoader('fake.json', (err, data) => {
-          test.ok(!err);
-          test.ok(data.success === true);
-          test.done();
-        });
+        SchemaInspector.httpSchemaLoader('fake.json')
+          .then(data => {
+            test.ok(data.success === true);
+            test.done();
+          });
       },
       httpSchemaLoaderFail(test) {
-        test.expect(2);
-        SchemaInspector.httpSchemaLoader('fail.json', (err, data) => {
-          test.ok(!data);
-          test.equal('Loading error: 500', err.message);
-          test.done();
-        });
+        test.expect(1);
+        SchemaInspector.httpSchemaLoader('fail.json')
+          .catch(err => {
+            test.equal('Loading error: 500', err.message);
+            test.done();
+          });
       },
       httpSchemaLoaderParseFail(test) {
         test.expect(1);
-        SchemaInspector.httpSchemaLoader('parseFail.json', (err, data) => {
-          test.ok(!data);
-          test.done();
-        });
+        SchemaInspector.httpSchemaLoader('parseFail.json')
+          .catch(() => {
+            test.ok(true);
+            test.done();
+          });
       },
       compileFail(test) {
         // Required properties cannot be empty.
@@ -136,11 +137,13 @@ module.exports = {
           {path: 'currentTuneIn', type: 'array'},
           {path: 'ratings.[item].systemValue', type: 'string'}
         ];
-        this.inspector.compileSync();
-        paths.forEach(path => {
-          test.equal(this.inspector.inspect(path.path).type, path.type);
-        });
-        test.done();
+        this.inspector.compile()
+          .then(() => {
+            paths.forEach(path => {
+              test.equal(this.inspector.inspect(path.path).type, path.type);
+            });
+            test.done();
+          });
       }
     }
   }

--- a/test/mocks/common.json
+++ b/test/mocks/common.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "title": "Common types re-usable across different schemas",
-  "id": "common.json#",
+  "$id": "common.json#",
   "time": {
     "type": "string",
     "description": "Not ISO-8601 compliant."
@@ -16,7 +16,9 @@
   },
   "multilingualString": {
     "type": "array",
-    "items": {"$ref": "#/localizedStringValue"}
+    "items": {
+      "$ref": "#/localizedStringValue"
+    }
   },
   "localizedStringValue": {
     "type": "object",
@@ -28,7 +30,9 @@
       }
     },
     "properties": {
-      "locale": {"$ref": "#/locale"}
+      "locale": {
+        "$ref": "#/locale"
+      }
     }
   },
   "locale": {

--- a/test/mocks/reltio-series.json
+++ b/test/mocks/reltio-series.json
@@ -1,11 +1,13 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "title": "Series data model Schema for the Reltio data",
-  "id": "reltio-series.json#",
+  "$id": "reltio-series.json#",
   "description": "Schema for an Series entity in the Reltio data model.",
   "additionalProperties": false,
   "type": "object",
-  "required": ["isRunning"],
+  "required": [
+    "isRunning"
+  ],
   "properties": {
     "finaleDate": {
       "description": "The date time the finale for this series was aired.",
@@ -22,7 +24,9 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["day"],
+        "required": [
+          "day"
+        ],
         "properties": {
           "day": {
             "type": "string",
@@ -36,8 +40,12 @@
               "Sunday"
             ]
           },
-          "customObject": {"$ref": "common.json#/custom"},
-          "endTime": {"$ref": "common.json#/time"}
+          "customObject": {
+            "$ref": "common.json#/custom"
+          },
+          "endTime": {
+            "$ref": "common.json#/time"
+          }
         }
       }
     },


### PR DESCRIPTION
BREAKING CHANGE: dependents will need to update their schemas to work with
ajv@^5.0.0. See the Migrating from Ajv 4.x.x instructions in the v5.0.0
[release tag](https://github.com/epoberezkin/ajv/releases/tag/5.0.0).

BREAKING CHANGE: compileSync has been removed since ajv cannot fetch remote
schemas synchronously now.